### PR TITLE
Add an ARG to allow installing an updated npm.

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:stretch-slim
 
 ARG NODE_EXTRA_PACKAGES
+ARG NPM_VERSION
 
 COPY files/ /tmp/files/
 RUN /tmp/files/configure

--- a/node/files/configure
+++ b/node/files/configure
@@ -8,6 +8,9 @@ cp /tmp/files/nodesource.gpg.key /etc/apt/trusted.gpg.d/nodesource.asc
 apt-get update
 
 apt-get install -y ssmtp sudo nodejs npm $NODE_EXTRA_PACKAGES
+if ! [ "z$NPM_VERSION" = "z" ]; then
+	npm install -g "npm@$NPM_VERSION"
+fi
 
 if ! [ "z$NPM_GLOBAL_INSTALL" = "z" ]; then
 	npm install -g $NPM_GLOBAL_INSTALL


### PR DESCRIPTION
Fixes: Brainfood-com/docker-image-recipes#1